### PR TITLE
feature: Det er bare lov å registrere unike opplysningstyper.

### DIFF
--- a/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/OpplysningSvarBygger.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/OpplysningSvarBygger.kt
@@ -14,9 +14,7 @@ class OpplysningSvarBygger<T : Comparable<T>>(
     private val gyldighetsperiode: Gyldighetsperiode,
 ) {
     companion object {
-        fun String.somOpplysningstype(): Opplysningstype<*> {
-            return Opplysningstype.finn { it.id == this }
-        }
+        fun String.somOpplysningstype() = Opplysningstype.finn { it.id == this }
     }
 
     fun opplysningSvar() =

--- a/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/OpplysningSvarBygger.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/OpplysningSvarBygger.kt
@@ -14,7 +14,9 @@ class OpplysningSvarBygger<T : Comparable<T>>(
     private val gyldighetsperiode: Gyldighetsperiode,
 ) {
     companion object {
-        fun String.somOpplysningstype() = Opplysningstype.typer.single { opplysningstype -> opplysningstype.id == this }
+        fun String.somOpplysningstype(): Opplysningstype<*> {
+            return Opplysningstype.finn { it.id == this }
+        }
     }
 
     fun opplysningSvar() =

--- a/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/mottak/OpplysningSvarMottak.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/mottak/OpplysningSvarMottak.kt
@@ -122,7 +122,7 @@ internal class OpplysningSvarMessage(private val packet: JsonMessage) : Hendelse
             packet["@løsning"].fields().forEach { (typeNavn, løsning) ->
                 logger.info { "Tok i mot opplysning av $typeNavn" }
 
-                if (Opplysningstype.typer.find { it.id == typeNavn } == null) {
+                if (runCatching { Opplysningstype.finn(typeNavn) }.isFailure) {
                     logger.error { "Ukjent opplysningstype: $typeNavn" }
                     return@forEach
                 }

--- a/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/repository/OpplysningerRepositoryPostgres.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/repository/OpplysningerRepositoryPostgres.kt
@@ -118,7 +118,8 @@ class OpplysningerRepositoryPostgres : OpplysningerRepository {
         private fun <T : Comparable<T>> Row.somOpplysningRad(datatype: Datatype<T>): OpplysningRad<T> {
             val opplysingerId = uuid("opplysninger_id")
             val id = uuid("id")
-            val opplysningstype = Opplysningstype(string("type_navn").id(string("type_id")), datatype)
+
+            val opplysningstype: Opplysningstype<T> = Opplysningstype.finn(string("type_navn").id(string("type_id")))
             val gyldighetsperiode =
                 Gyldighetsperiode(
                     localDateOrNull("gyldig_fom") ?: LocalDate.MIN,

--- a/mediator/src/test/kotlin/no/nav/dagpenger/behandling/TestOpplysningstyper.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/behandling/TestOpplysningstyper.kt
@@ -1,0 +1,15 @@
+package no.nav.dagpenger.behandling
+
+import no.nav.dagpenger.opplysning.Opplysningstype
+import no.nav.dagpenger.opplysning.id
+
+internal object TestOpplysningstyper {
+    val baseOpplysningstype = Opplysningstype.somDato("Base")
+    val utledetOpplysningstype = Opplysningstype.somHeltall("Utledet")
+    val maksdato = Opplysningstype.somDato("MaksDato")
+    val mindato = Opplysningstype.somDato("MinDato")
+    val heltall = Opplysningstype.somHeltall("heltall")
+    val boolsk = Opplysningstype.somBoolsk("boolsk")
+    val dato = Opplysningstype.somDato("Dato")
+    val desimal = Opplysningstype.somHeltall("Desimal".id("desimaltall"))
+}

--- a/modell/src/main/kotlin/no/nav/dagpenger/behandling/modell/hendelser/SøknadInnsendtHendelse.kt
+++ b/modell/src/main/kotlin/no/nav/dagpenger/behandling/modell/hendelser/SøknadInnsendtHendelse.kt
@@ -37,11 +37,15 @@ class SøknadInnsendtHendelse(
 
     override fun avklarer(): Opplysningstype<Boolean> = RettTilDagpenger.kravPåDagpenger
 
+    private companion object {
+        val fagsakIdOpplysningstype = Opplysningstype.somHeltall("fagsakId")
+    }
+
     override fun behandling() =
         Behandling(
             this,
             listOf(
-                Faktum(Opplysningstype.somHeltall("fagsakId"), fagsakId),
+                Faktum(fagsakIdOpplysningstype, fagsakId),
             ),
         )
 }

--- a/modell/src/test/kotlin/no/nav/dagpenger/behandling/modell/BehandlingTest.kt
+++ b/modell/src/test/kotlin/no/nav/dagpenger/behandling/modell/BehandlingTest.kt
@@ -25,7 +25,10 @@ internal class BehandlingTest {
             gjelderDato = LocalDate.now(),
             fagsakId = 1,
         )
-    private val tidligereOpplysning = Opplysningstype.somDesimaltall("opplysning-fra-tidligere-behandling")
+
+    private companion object {
+        val tidligereOpplysning = Opplysningstype.somDesimaltall("opplysning-fra-tidligere-behandling")
+    }
 
     @Test
     fun `Behandling basert på tidligere behandlinger`() {

--- a/opplysninger/src/main/kotlin/no/nav/dagpenger/opplysning/Opplysningstype.kt
+++ b/opplysninger/src/main/kotlin/no/nav/dagpenger/opplysning/Opplysningstype.kt
@@ -50,7 +50,6 @@ class Opplysningstype<T : Comparable<T>>(
         }
 
         private fun registrer(opplysningstype: Opplysningstype<*>) {
-            // @todo: Vi trenger denne sjekken men krever en del refaktorering av testene
             require(!typer.contains(opplysningstype)) { "Opplysningstype $opplysningstype er allerede registrert" }
             typer.add(opplysningstype)
         }

--- a/opplysninger/src/main/kotlin/no/nav/dagpenger/opplysning/Opplysningstype.kt
+++ b/opplysninger/src/main/kotlin/no/nav/dagpenger/opplysning/Opplysningstype.kt
@@ -32,11 +32,26 @@ class Opplysningstype<T : Comparable<T>>(
     }
 
     companion object {
-        val typer = mutableSetOf<Opplysningstype<*>>()
+        private val typer = mutableSetOf<Opplysningstype<*>>()
+
+        fun finn(predikat: (Opplysningstype<*>) -> Boolean): Opplysningstype<*> {
+            return typer.single { predikat(it) }
+        }
+
+        fun finn(id: String): Opplysningstype<*> {
+            return finn { it.id == id }
+        }
+
+        fun <T : Comparable<T>> finn(opplysningTypeId: OpplysningTypeId): Opplysningstype<T> {
+            return (
+                typer.find { it.opplysningTypeId == opplysningTypeId }
+                    ?: throw IllegalArgumentException("Fant ikke opplysningstype $opplysningTypeId")
+            ) as Opplysningstype<T>
+        }
 
         private fun registrer(opplysningstype: Opplysningstype<*>) {
             // @todo: Vi trenger denne sjekken men krever en del refaktorering av testene
-            // require(!typer.contains(opplysningstype)) { "Opplysningstype $opplysningstype er allerede registrert" }
+            require(!typer.contains(opplysningstype)) { "Opplysningstype $opplysningstype er allerede registrert" }
             typer.add(opplysningstype)
         }
 

--- a/opplysninger/src/test/kotlin/no/nav/dagpenger/opplysning/OpplysningTest.kt
+++ b/opplysninger/src/test/kotlin/no/nav/dagpenger/opplysning/OpplysningTest.kt
@@ -2,6 +2,7 @@ package no.nav.dagpenger.opplysning
 
 import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.matchers.shouldBe
+import no.nav.dagpenger.opplysning.TestOpplysningstyper.dato1
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
@@ -11,20 +12,20 @@ import java.util.UUID
 class OpplysningTest {
     @Test
     fun `Har opplysningstype`() {
-        val opplysning = Faktum(Opplysningstype.somDato("Fødselsdato"), LocalDate.now())
-        assertTrue(opplysning.er(Opplysningstype.somDato("Fødselsdato")))
+        val opplysning = Faktum(dato1, LocalDate.now())
+        assertTrue(opplysning.er(dato1))
     }
 
     @Test
     fun `opplysning har uuid versjon 7 id`() {
-        val opplysning = Faktum(Opplysningstype.somDato("Fødselsdato"), LocalDate.now())
+        val opplysning = Faktum(dato1, LocalDate.now())
         shouldNotThrowAny { UUID.fromString(opplysning.id.toString()) }
         opplysning.id.version() shouldBe 7
     }
 
     @Test
     fun `opplysning har opprettet dato`() {
-        val opplysning = Faktum(Opplysningstype.somDato("Fødselsdato"), LocalDate.now())
+        val opplysning = Faktum(dato1, LocalDate.now())
         assertTrue(opplysning.opprettet.isBefore(LocalDateTime.now()))
     }
 }

--- a/opplysninger/src/test/kotlin/no/nav/dagpenger/opplysning/OpplysningerTest.kt
+++ b/opplysninger/src/test/kotlin/no/nav/dagpenger/opplysning/OpplysningerTest.kt
@@ -1,5 +1,9 @@
 package no.nav.dagpenger.opplysning
 
+import no.nav.dagpenger.opplysning.TestOpplysningstyper.desimaltall
+import no.nav.dagpenger.opplysning.TestOpplysningstyper.foreldrevilkår
+import no.nav.dagpenger.opplysning.TestOpplysningstyper.undervilkår1
+import no.nav.dagpenger.opplysning.TestOpplysningstyper.undervilkår2
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -8,89 +12,81 @@ import kotlin.test.assertEquals
 class OpplysningerTest {
     @Test
     fun `vilkår er avhengig av andre vilkår`() {
-        val vilkår = Opplysningstype.somBoolsk("Vilkår")
-        val minsteinntekt = Opplysningstype.somBoolsk("Minsteinntekt", vilkår)
-        val alder = Opplysningstype.somBoolsk("Alder", vilkår)
-
         val opplysninger =
             Opplysninger().also {
                 Regelkjøring(1.mai, it)
             }
 
-        opplysninger.leggTil(Faktum(minsteinntekt, true))
-        opplysninger.leggTil(Faktum(alder, true))
-        opplysninger.leggTil(Faktum(vilkår, true))
+        opplysninger.leggTil(Faktum(undervilkår1, true))
+        opplysninger.leggTil(Faktum(undervilkår2, true))
+        opplysninger.leggTil(Faktum(foreldrevilkår, true))
 
-        assertTrue(opplysninger.har(minsteinntekt))
-        assertTrue(opplysninger.har(alder))
-        assertTrue(opplysninger.har(vilkår))
+        assertTrue(opplysninger.har(undervilkår1))
+        assertTrue(opplysninger.har(undervilkår2))
+        assertTrue(opplysninger.har(foreldrevilkår))
     }
 
     @Test
     fun `tillater ikke overlappende opplysninger av samme type`() {
-        val opplysningstype = Opplysningstype.somDesimaltall("Type")
         val opplysninger =
             Opplysninger().also {
                 Regelkjøring(1.mai, it)
             }
 
-        opplysninger.leggTil(Faktum(opplysningstype, 0.5, Gyldighetsperiode(1.mai, 10.mai)))
+        opplysninger.leggTil(Faktum(desimaltall, 0.5, Gyldighetsperiode(1.mai, 10.mai)))
         assertThrows<IllegalArgumentException> {
-            opplysninger.leggTil(Faktum(opplysningstype, 0.5))
+            opplysninger.leggTil(Faktum(desimaltall, 0.5))
         }
-        opplysninger.leggTil(Faktum(opplysningstype, 1.5, Gyldighetsperiode(11.mai)))
+        opplysninger.leggTil(Faktum(desimaltall, 1.5, Gyldighetsperiode(11.mai)))
 
-        assertEquals(0.5, opplysninger.finnOpplysning(opplysningstype).verdi)
-        assertEquals(0.5, opplysninger.finnOpplysning(opplysningstype).verdi)
+        assertEquals(0.5, opplysninger.finnOpplysning(desimaltall).verdi)
+        assertEquals(0.5, opplysninger.finnOpplysning(desimaltall).verdi)
         Regelkjøring(15.mai, opplysninger) // Bytt til 15. mai for regelkjøringen
-        assertEquals(1.5, opplysninger.finnOpplysning(opplysningstype).verdi)
+        assertEquals(1.5, opplysninger.finnOpplysning(desimaltall).verdi)
     }
 
     @Test
     fun `opplysninger kan erstattes om de gjelder samme periode`() {
-        val opplysningstype = Opplysningstype.somDesimaltall("Type")
         val opplysninger =
             Opplysninger().also {
                 Regelkjøring(1.mai, it)
             }
 
         val gyldighetsperiode = Gyldighetsperiode(1.mai, 10.mai)
-        opplysninger.leggTil(Faktum(opplysningstype, 0.5, gyldighetsperiode))
-        opplysninger.leggTil(Faktum(opplysningstype, 1.5, gyldighetsperiode))
+        opplysninger.leggTil(Faktum(desimaltall, 0.5, gyldighetsperiode))
+        opplysninger.leggTil(Faktum(desimaltall, 1.5, gyldighetsperiode))
 
-        assertEquals(1.5, opplysninger.finnOpplysning(opplysningstype).verdi)
+        assertEquals(1.5, opplysninger.finnOpplysning(desimaltall).verdi)
     }
 
     @Test
     fun `opplysninger kan erstattes om de bare overlapper på halen`() {
-        val opplysningstype = Opplysningstype.somDesimaltall("Type")
         val opplysninger =
             Opplysninger().also {
                 Regelkjøring(8.mai, it)
             }
 
-        opplysninger.leggTil(Faktum(opplysningstype, 0.5, Gyldighetsperiode(1.mai, 10.mai)))
-        opplysninger.leggTil(Faktum(opplysningstype, 1.5, Gyldighetsperiode(5.mai, 15.mai)))
+        opplysninger.leggTil(Faktum(desimaltall, 0.5, Gyldighetsperiode(1.mai, 10.mai)))
+        opplysninger.leggTil(Faktum(desimaltall, 1.5, Gyldighetsperiode(5.mai, 15.mai)))
 
-        assertEquals(1.5, opplysninger.finnOpplysning(opplysningstype).verdi)
+        assertEquals(1.5, opplysninger.finnOpplysning(desimaltall).verdi)
     }
 
     @Test
     fun `opplysninger kan arve tidligere opplysninger`() {
-        val opplysningstype = Opplysningstype.somDesimaltall("Type")
-        val tidligereOpplysninger = Opplysninger(listOf(Faktum(opplysningstype, 0.5, Gyldighetsperiode(1.mai, 20.mai))))
+        val tidligereOpplysninger = Opplysninger(listOf(Faktum(desimaltall, 0.5, Gyldighetsperiode(1.mai, 20.mai))))
         val opplysninger =
             Opplysninger(tidligereOpplysninger).also {
                 Regelkjøring(15.mai, it)
             }
 
         // Vi får hentet ut opplysning fra tidligere behandlinger
-        assertEquals(0.5, opplysninger.finnOpplysning(opplysningstype).verdi)
+        assertEquals(0.5, opplysninger.finnOpplysning(desimaltall).verdi)
 
         assertThrows<IllegalArgumentException> {
-            opplysninger.leggTil(Faktum(opplysningstype, 1.5, Gyldighetsperiode(15.mai, 18.mai)))
+            opplysninger.leggTil(Faktum(desimaltall, 1.5, Gyldighetsperiode(15.mai, 18.mai)))
         }
 
-        opplysninger.leggTil(Faktum(opplysningstype, 1.5, Gyldighetsperiode(21.mai)))
+        opplysninger.leggTil(Faktum(desimaltall, 1.5, Gyldighetsperiode(21.mai)))
     }
 }

--- a/opplysninger/src/test/kotlin/no/nav/dagpenger/opplysning/OpplysningstypeTest.kt
+++ b/opplysninger/src/test/kotlin/no/nav/dagpenger/opplysning/OpplysningstypeTest.kt
@@ -2,32 +2,30 @@ package no.nav.dagpenger.opplysning
 
 import io.kotest.matchers.equals.shouldBeEqual
 import io.kotest.matchers.equals.shouldNotBeEqual
+import no.nav.dagpenger.opplysning.TestOpplysningstyper.dato1
+import no.nav.dagpenger.opplysning.TestOpplysningstyper.foreldrevilkår
+import no.nav.dagpenger.opplysning.TestOpplysningstyper.undervilkår1
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 class OpplysningstypeTest {
     @Test
     fun `likhet test`() {
-        val fødselsdato = Opplysningstype.somDato("Fødselsdato")
-        fødselsdato shouldBeEqual fødselsdato
-        fødselsdato.hashCode() shouldBeEqual fødselsdato.hashCode()
-        Opplysningstype.somDato("Fødselsdato") shouldBeEqual fødselsdato
-        fødselsdato shouldNotBeEqual Any()
+        dato1 shouldBeEqual dato1
+        dato1.hashCode() shouldBeEqual dato1.hashCode()
+        dato1 shouldBeEqual dato1
+        dato1 shouldNotBeEqual Any()
     }
 
     @Test
     fun `enkle opplysningstyper`() {
-        val fødselsdato = Opplysningstype.somDato("Fødselsdato")
-        assertTrue(fødselsdato.er(fødselsdato))
+        assertTrue(dato1.er(dato1))
     }
 
     @Test
     fun `hierarkiske opplysningstyper`() {
-        val vilkår = Opplysningstype.somDato("Vilkår")
-        val minsteinntekt = Opplysningstype.somDato("Minsteinntekt", vilkår)
-
-        assertTrue(minsteinntekt.er(minsteinntekt))
-        assertTrue(minsteinntekt.er(vilkår))
+        assertTrue(undervilkår1.er(foreldrevilkår))
+        assertTrue(undervilkår1.er(foreldrevilkår))
 
 //        assertEquals(listOf(minsteinntekt), vilkår.bestårAv())
     }

--- a/opplysninger/src/test/kotlin/no/nav/dagpenger/opplysning/RegelTest.kt
+++ b/opplysninger/src/test/kotlin/no/nav/dagpenger/opplysning/RegelTest.kt
@@ -2,36 +2,36 @@ package no.nav.dagpenger.opplysning
 
 import io.kotest.assertions.throwables.shouldNotThrow
 import io.kotest.matchers.shouldBe
+import no.nav.dagpenger.opplysning.TestOpplysningstyper.boolskA
+import no.nav.dagpenger.opplysning.TestOpplysningstyper.boolskB
+import no.nav.dagpenger.opplysning.TestOpplysningstyper.boolskC
 import no.nav.dagpenger.opplysning.regel.alle
 import kotlin.test.Test
 
 class RegelTest {
     @Test
     fun `Regel produserer bare nye opplysningen hvis det den avhenger av er nyere enn det den har produsert`() {
-        val a = Opplysningstype.somBoolsk("A")
-        val b = Opplysningstype.somBoolsk("B")
-        val c = Opplysningstype.somBoolsk("C")
         val regelsett =
             Regelsett("regelsett") {
-                regel(c) {
-                    alle(a, b)
+                regel(boolskC) {
+                    alle(boolskA, boolskB)
                 }
             }
 
         val opplysninger = Opplysninger()
         val regelkjøring1 = Regelkjøring(1.mai, opplysninger, regelsett)
-        val opplysning = Faktum(a, true, Gyldighetsperiode(1.januar, 2.mai))
+        val opplysning = Faktum(boolskA, true, Gyldighetsperiode(1.januar, 2.mai))
         opplysninger.leggTil(opplysning)
-        opplysninger.leggTil(Faktum(b, true))
+        opplysninger.leggTil(Faktum(boolskB, true))
         regelkjøring1.evaluer()
-        opplysninger.finnOpplysning(c).verdi shouldBe true
+        opplysninger.finnOpplysning(boolskC).verdi shouldBe true
 
         // Første forsøk på å fastsette A var feil.
         val regelkjøring2 = Regelkjøring(1.mai, opplysninger, regelsett)
-        opplysninger.leggTil(Faktum(a, false, Gyldighetsperiode(1.januar, 2.mai)))
+        opplysninger.leggTil(Faktum(boolskA, false, Gyldighetsperiode(1.januar, 2.mai)))
         shouldNotThrow<IllegalArgumentException> { regelkjøring2.evaluer() }
 
         // Endring av A fører til at C blir beregnet på nytt
-        opplysninger.finnOpplysning(c).verdi shouldBe false
+        opplysninger.finnOpplysning(boolskC).verdi shouldBe false
     }
 }

--- a/opplysninger/src/test/kotlin/no/nav/dagpenger/opplysning/RegelkjøringTest.kt
+++ b/opplysninger/src/test/kotlin/no/nav/dagpenger/opplysning/RegelkjøringTest.kt
@@ -1,5 +1,8 @@
 package no.nav.dagpenger.opplysning
 
+import no.nav.dagpenger.opplysning.TestOpplysningstyper.a
+import no.nav.dagpenger.opplysning.TestOpplysningstyper.b
+import no.nav.dagpenger.opplysning.TestOpplysningstyper.c
 import no.nav.dagpenger.opplysning.regel.enAv
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -7,14 +10,13 @@ import org.junit.jupiter.api.assertThrows
 class RegelkjøringTest {
     @Test
     fun `Regelsett kan ikke inneholder flere regler som produserer samme opplysningstype`() {
-        val a = Opplysningstype.somBoolsk("A")
         val regelsett1 =
             Regelsett("regelsett") {
-                regel(a) { enAv(Opplysningstype.somBoolsk("B")) }
+                regel(a) { enAv(b) }
             }
         val regelsett2 =
             Regelsett("regelsett") {
-                regel(a) { enAv(Opplysningstype.somBoolsk("C")) }
+                regel(a) { enAv(c) }
             }
 
         assertThrows<IllegalArgumentException> {

--- a/opplysninger/src/test/kotlin/no/nav/dagpenger/opplysning/RegelsettTest.kt
+++ b/opplysninger/src/test/kotlin/no/nav/dagpenger/opplysning/RegelsettTest.kt
@@ -1,15 +1,15 @@
 package no.nav.dagpenger.opplysning
 
 import io.kotest.matchers.shouldBe
+import no.nav.dagpenger.opplysning.TestOpplysningstyper.faktorA
+import no.nav.dagpenger.opplysning.TestOpplysningstyper.faktorB
+import no.nav.dagpenger.opplysning.TestOpplysningstyper.grunntall
+import no.nav.dagpenger.opplysning.TestOpplysningstyper.produserer
 import no.nav.dagpenger.opplysning.regel.multiplikasjon
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 class RegelsettTest {
-    private val grunntall = Opplysningstype.somDesimaltall("A")
-    private val faktorA = Opplysningstype.somDesimaltall("FaktorA")
-    private val faktorB = Opplysningstype.somDesimaltall("FaktorB")
-    private val produserer = Opplysningstype.somDesimaltall("Output")
     private val regelsett
         get() =
             Regelsett("regelsett") {

--- a/opplysninger/src/test/kotlin/no/nav/dagpenger/opplysning/TestOpplysningstyper.kt
+++ b/opplysninger/src/test/kotlin/no/nav/dagpenger/opplysning/TestOpplysningstyper.kt
@@ -1,0 +1,20 @@
+package no.nav.dagpenger.opplysning
+
+internal object TestOpplysningstyper {
+    val dato1 by lazy { Opplysningstype.somDato("dato1") }
+    val dato2 by lazy { Opplysningstype.somDato("dato2") }
+    val desimaltall by lazy { Opplysningstype.somDesimaltall("desimaltall") }
+    val a by lazy { Opplysningstype.somBoolsk("A") }
+    val b by lazy { Opplysningstype.somBoolsk("B") }
+    val c by lazy { Opplysningstype.somBoolsk("C") }
+    val grunntall by lazy { Opplysningstype.somDesimaltall("Grunntall") }
+    val faktorA by lazy { Opplysningstype.somDesimaltall("FaktorA") }
+    val faktorB by lazy { Opplysningstype.somDesimaltall("FaktorB") }
+    val produserer by lazy { Opplysningstype.somDesimaltall("Resultat") }
+    val boolskB by lazy { Opplysningstype.somBoolsk("boolsk B") }
+    val boolskC by lazy { Opplysningstype.somBoolsk("boolsk C") }
+    val boolskA by lazy { Opplysningstype.somBoolsk("boolsk A") }
+    val foreldrevilkår by lazy { Opplysningstype.somBoolsk("Foreldrevilkår") }
+    val undervilkår1 by lazy { Opplysningstype.somBoolsk("Undervilkår1", foreldrevilkår) }
+    val undervilkår2 by lazy { Opplysningstype.somBoolsk("Undervilkår2", foreldrevilkår) }
+}

--- a/opplysninger/src/test/kotlin/no/nav/dagpenger/opplysning/dag/RegeltreByggerTest.kt
+++ b/opplysninger/src/test/kotlin/no/nav/dagpenger/opplysning/dag/RegeltreByggerTest.kt
@@ -1,7 +1,9 @@
 package no.nav.dagpenger.opplysning.dag
 
-import no.nav.dagpenger.opplysning.Opplysningstype
 import no.nav.dagpenger.opplysning.Regelsett
+import no.nav.dagpenger.opplysning.TestOpplysningstyper.faktorA
+import no.nav.dagpenger.opplysning.TestOpplysningstyper.faktorB
+import no.nav.dagpenger.opplysning.TestOpplysningstyper.produserer
 import no.nav.dagpenger.opplysning.regel.multiplikasjon
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
@@ -10,10 +12,7 @@ import kotlin.test.assertContains
 class RegeltreByggerTest {
     @Test
     fun `bygg regeltre`() {
-        val a = Opplysningstype.somDesimaltall("A")
-        val b = Opplysningstype.somDesimaltall("B")
-        val c = Opplysningstype.somDesimaltall("A * B")
-        val regelsett = Regelsett("regelsett") { regel(c) { multiplikasjon(a, b) } }
+        val regelsett = Regelsett("regelsett") { regel(produserer) { multiplikasjon(faktorA, faktorB) } }
 
         val regeltre = RegeltreBygger(regelsett.regler()).dag()
         assertEquals(3, regeltre.nodes.size, "Har en node for hver opplysningstype")
@@ -23,7 +22,7 @@ class RegeltreByggerTest {
         assertEquals(2, leafNodes.size, "Har to løvnoder")
 
         val opplysningerUtenAvhengigheter = leafNodes.map { it.data }
-        assertContains(opplysningerUtenAvhengigheter, a)
-        assertContains(opplysningerUtenAvhengigheter, b)
+        assertContains(opplysningerUtenAvhengigheter, faktorA)
+        assertContains(opplysningerUtenAvhengigheter, faktorB)
     }
 }

--- a/opplysninger/src/test/kotlin/no/nav/dagpenger/opplysning/dag/printer/DAGPrinterTest.kt
+++ b/opplysninger/src/test/kotlin/no/nav/dagpenger/opplysning/dag/printer/DAGPrinterTest.kt
@@ -1,7 +1,9 @@
 package no.nav.dagpenger.opplysning.dag.printer
 
-import no.nav.dagpenger.opplysning.Opplysningstype
 import no.nav.dagpenger.opplysning.Regelsett
+import no.nav.dagpenger.opplysning.TestOpplysningstyper.faktorA
+import no.nav.dagpenger.opplysning.TestOpplysningstyper.faktorB
+import no.nav.dagpenger.opplysning.TestOpplysningstyper.produserer
 import no.nav.dagpenger.opplysning.dag.RegeltreBygger
 import no.nav.dagpenger.opplysning.regel.multiplikasjon
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -9,10 +11,7 @@ import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
 class DAGPrinterTest {
-    private val a = Opplysningstype.somDesimaltall("A")
-    private val b = Opplysningstype.somDesimaltall("B")
-    private val c = Opplysningstype.somDesimaltall("A * B")
-    private val regelsett = Regelsett("regelsett") { regel(c) { multiplikasjon(a, b) } }
+    private val regelsett = Regelsett("regelsett") { regel(produserer) { multiplikasjon(faktorA, faktorB) } }
 
     private val regeltre = RegeltreBygger(regelsett.regler()).dag()
 
@@ -23,13 +22,13 @@ class DAGPrinterTest {
         assertEquals(
             expected =
                 """
-                A * B: opplysning om A * B
+                Resultat: opplysning om Resultat
                   | Multiplikasjon
-                  A: opplysning om A
+                  FaktorA: opplysning om FaktorA
                   | Multiplikasjon
-                  B: opplysning om B
+                  FaktorB: opplysning om FaktorB
                 """.trimIndent(),
-            actual = prettyPrinter.toPrint { it.data == c },
+            actual = prettyPrinter.toPrint { it.data == produserer },
         )
     }
 

--- a/opplysninger/src/test/kotlin/no/nav/dagpenger/opplysning/regel/EnAvTest.kt
+++ b/opplysninger/src/test/kotlin/no/nav/dagpenger/opplysning/regel/EnAvTest.kt
@@ -3,47 +3,46 @@ package no.nav.dagpenger.opplysning.regel
 import io.kotest.matchers.shouldBe
 import no.nav.dagpenger.opplysning.Faktum
 import no.nav.dagpenger.opplysning.Opplysninger
-import no.nav.dagpenger.opplysning.Opplysningstype
 import no.nav.dagpenger.opplysning.Regelkjøring
 import no.nav.dagpenger.opplysning.Regelsett
+import no.nav.dagpenger.opplysning.TestOpplysningstyper.boolskA
+import no.nav.dagpenger.opplysning.TestOpplysningstyper.boolskB
+import no.nav.dagpenger.opplysning.TestOpplysningstyper.boolskC
 import no.nav.dagpenger.opplysning.mai
 import org.junit.jupiter.api.Test
 
 internal class EnAvTest {
-    private val opplysningB = Opplysningstype.somBoolsk("B")
-    private val opplysningC = Opplysningstype.somBoolsk("C")
-    private val produserer = Opplysningstype.somBoolsk("A")
     private val opplysninger = Opplysninger()
     private val regelkjøring =
         Regelkjøring(
             1.mai,
             opplysninger,
             Regelsett("regelsett") {
-                regel(produserer) { enAv(opplysningB, opplysningC) }
+                regel(boolskA) { enAv(boolskB, boolskC) }
             },
         )
 
     @Test
     fun `hvis en av opplysningene er sanne så er utledningen sann`() {
-        opplysninger.leggTil(Faktum(opplysningB, false))
-        opplysninger.leggTil(Faktum(opplysningC, true))
-        val utledet = opplysninger.finnOpplysning(produserer)
+        opplysninger.leggTil(Faktum(boolskB, false))
+        opplysninger.leggTil(Faktum(boolskC, true))
+        val utledet = opplysninger.finnOpplysning(boolskA)
         utledet.verdi shouldBe true
     }
 
     @Test
     fun `hvis ingen av opplysningene er sanne så er utledningen usann`() {
-        opplysninger.leggTil(Faktum(opplysningB, false))
-        opplysninger.leggTil(Faktum(opplysningC, false))
-        val utledet = opplysninger.finnOpplysning(produserer)
+        opplysninger.leggTil(Faktum(boolskB, false))
+        opplysninger.leggTil(Faktum(boolskC, false))
+        val utledet = opplysninger.finnOpplysning(boolskA)
         utledet.verdi shouldBe false
     }
 
     @Test
     fun `hvis begge opplysningene er sanne så er utledningen sann`() {
-        opplysninger.leggTil(Faktum(opplysningB, true))
-        opplysninger.leggTil(Faktum(opplysningC, true))
-        val utledet = opplysninger.finnOpplysning(produserer)
+        opplysninger.leggTil(Faktum(boolskB, true))
+        opplysninger.leggTil(Faktum(boolskC, true))
+        val utledet = opplysninger.finnOpplysning(boolskA)
         utledet.verdi shouldBe true
         utledet.verdi shouldBe true
     }

--- a/opplysninger/src/test/kotlin/no/nav/dagpenger/opplysning/regel/MultiplikasjonTest.kt
+++ b/opplysninger/src/test/kotlin/no/nav/dagpenger/opplysning/regel/MultiplikasjonTest.kt
@@ -2,36 +2,31 @@ package no.nav.dagpenger.opplysning.regel
 
 import no.nav.dagpenger.opplysning.Faktum
 import no.nav.dagpenger.opplysning.Opplysninger
-import no.nav.dagpenger.opplysning.Opplysningstype
 import no.nav.dagpenger.opplysning.Regelkjøring
 import no.nav.dagpenger.opplysning.Regelsett
+import no.nav.dagpenger.opplysning.TestOpplysningstyper.faktorA
+import no.nav.dagpenger.opplysning.TestOpplysningstyper.faktorB
+import no.nav.dagpenger.opplysning.TestOpplysningstyper.produserer
 import no.nav.dagpenger.opplysning.mai
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 class MultiplikasjonTest {
-    private val sum =
-        Opplysningstype.somDesimaltall("SUM")
-    private val a =
-        Opplysningstype.somDesimaltall("A")
-    private val b =
-        Opplysningstype.somDesimaltall("B")
-
     private val opplysninger = Opplysninger()
     private val regelkjøring =
         Regelkjøring(
             1.mai,
             opplysninger,
             Regelsett("regelsett") {
-                regel(sum) { multiplikasjon(a, b) }
+                regel(produserer) { multiplikasjon(faktorA, faktorB) }
             },
         )
 
     @Test
     fun `multiplikasjon regel`() {
-        opplysninger.leggTil(Faktum(a, 2.0))
-        opplysninger.leggTil(Faktum(b, 2.0))
-        val utledet = opplysninger.finnOpplysning(sum)
+        opplysninger.leggTil(Faktum(faktorA, 2.0))
+        opplysninger.leggTil(Faktum(faktorB, 2.0))
+        val utledet = opplysninger.finnOpplysning(produserer)
         assertEquals(4.0, utledet.verdi)
     }
 }

--- a/opplysninger/src/test/kotlin/no/nav/dagpenger/opplysning/regel/SisteDagIMånedEllerLikTest.kt
+++ b/opplysninger/src/test/kotlin/no/nav/dagpenger/opplysning/regel/SisteDagIMånedEllerLikTest.kt
@@ -2,41 +2,39 @@ package no.nav.dagpenger.opplysning.regel
 
 import no.nav.dagpenger.opplysning.Faktum
 import no.nav.dagpenger.opplysning.Opplysninger
-import no.nav.dagpenger.opplysning.Opplysningstype
 import no.nav.dagpenger.opplysning.Regelkjøring
 import no.nav.dagpenger.opplysning.Regelsett
+import no.nav.dagpenger.opplysning.TestOpplysningstyper.boolskA
+import no.nav.dagpenger.opplysning.TestOpplysningstyper.faktorA
+import no.nav.dagpenger.opplysning.TestOpplysningstyper.faktorB
 import no.nav.dagpenger.opplysning.mai
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 class SisteDagIMånedEllerLikTest {
-    private val vilkår = Opplysningstype.somBoolsk("Vilkår")
-    private val a = Opplysningstype.somDesimaltall("A")
-    private val b = Opplysningstype.somDesimaltall("B")
-
     private val opplysninger = Opplysninger()
     private val regelkjøring =
         Regelkjøring(
             1.mai,
             opplysninger,
             Regelsett("regelsett") {
-                regel(vilkår) { størreEnnEllerLik(a, b) }
+                regel(boolskA) { størreEnnEllerLik(faktorA, faktorB) }
             },
         )
 
     @Test
     fun `større enn`() {
-        opplysninger.leggTil(Faktum(a, 2.0))
-        opplysninger.leggTil(Faktum(b, 1.0))
-        val utledet = opplysninger.finnOpplysning(vilkår)
+        opplysninger.leggTil(Faktum(faktorA, 2.0))
+        opplysninger.leggTil(Faktum(faktorB, 1.0))
+        val utledet = opplysninger.finnOpplysning(boolskA)
         assertTrue(utledet.verdi)
     }
 
     @Test
     fun `ikke større enn`() {
-        opplysninger.leggTil(Faktum(a, 2.0))
-        opplysninger.leggTil(Faktum(b, 1.0))
-        val utledet = opplysninger.finnOpplysning(vilkår)
+        opplysninger.leggTil(Faktum(faktorA, 2.0))
+        opplysninger.leggTil(Faktum(faktorB, 1.0))
+        val utledet = opplysninger.finnOpplysning(boolskA)
         assertTrue(utledet.verdi)
     }
 }

--- a/opplysninger/src/test/kotlin/no/nav/dagpenger/opplysning/regel/dato/FørsteArbeidsdagTest.kt
+++ b/opplysninger/src/test/kotlin/no/nav/dagpenger/opplysning/regel/dato/FørsteArbeidsdagTest.kt
@@ -2,48 +2,44 @@ package no.nav.dagpenger.opplysning.regel.dato
 
 import no.nav.dagpenger.opplysning.Hypotese
 import no.nav.dagpenger.opplysning.Opplysninger
-import no.nav.dagpenger.opplysning.Opplysningstype
 import no.nav.dagpenger.opplysning.Regelkjøring
 import no.nav.dagpenger.opplysning.Regelsett
+import no.nav.dagpenger.opplysning.TestOpplysningstyper.dato1
+import no.nav.dagpenger.opplysning.TestOpplysningstyper.dato2
 import no.nav.dagpenger.opplysning.mai
 import java.time.LocalDate
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class FørsteArbeidsdagTest {
-    private val dato =
-        Opplysningstype.somDato("dato")
-    private val arbeidsdag =
-        Opplysningstype.somDato("arbeidsdag")
-
     private val opplysninger = Opplysninger()
     private val regelkjøring =
         Regelkjøring(
             1.mai,
             opplysninger,
             Regelsett("finn første arbeidsdag for en dato") {
-                regel(arbeidsdag) { førsteArbeidsdag(dato) }
+                regel(dato2) { førsteArbeidsdag(dato1) }
             },
         )
 
     @Test
     fun `Fredag 5 juli  2019 er en arbeidsag`() {
-        opplysninger.leggTil(Hypotese(dato, LocalDate.of(2019, 7, 5)))
-        val utledet = opplysninger.finnOpplysning(arbeidsdag)
+        opplysninger.leggTil(Hypotese(dato1, LocalDate.of(2019, 7, 5)))
+        val utledet = opplysninger.finnOpplysning(dato2)
         assertEquals(LocalDate.of(2019, 7, 5), utledet.verdi)
     }
 
     @Test
     fun `Fredag 5 mai  2019 er en søndag og dermed blir første arbeidsdag 6 mai`() {
-        opplysninger.leggTil(Hypotese(dato, LocalDate.of(2019, 5, 5)))
-        val utledet = opplysninger.finnOpplysning(arbeidsdag)
+        opplysninger.leggTil(Hypotese(dato1, LocalDate.of(2019, 5, 5)))
+        val utledet = opplysninger.finnOpplysning(dato2)
         assertEquals(LocalDate.of(2019, 5, 6), utledet.verdi)
     }
 
     @Test
     fun `Første arbeidsdag etter 5 oktober 2024 er mandag 7 oktober 2024`() {
-        opplysninger.leggTil(Hypotese(dato, LocalDate.of(2024, 10, 5)))
-        val utledet = opplysninger.finnOpplysning(arbeidsdag)
+        opplysninger.leggTil(Hypotese(dato1, LocalDate.of(2024, 10, 5)))
+        val utledet = opplysninger.finnOpplysning(dato2)
         assertEquals(LocalDate.of(2024, 10, 7), utledet.verdi)
     }
 }


### PR DESCRIPTION
Endring som gjør at en kan bare registrere unike opplysningstype. Unike pt er at det ikke kan finnes to opplysninger med samme navn. 

Oppdaget da vi kodet utdanning at det er lett å gå på en smell her. I og med at vi skal lage flere vilkår er det greit å få en tidlig varsel på når en lager duplikate opplysninger. 