### PR TITLE
Denormaliser avklaringkode og inline det rett i avklaring

### DIFF
--- a/mediator/src/main/resources/db/migration/V14__DENORMALISER_AVKLARING.sql
+++ b/mediator/src/main/resources/db/migration/V14__DENORMALISER_AVKLARING.sql
@@ -1,0 +1,27 @@
+-- Flytt data fra avklaringkode til avklaring
+ALTER TABLE avklaring
+    ADD COLUMN kode          TEXT,
+    ADD COLUMN tittel        TEXT,
+    ADD COLUMN beskrivelse   TEXT,
+    ADD COLUMN kan_kvitteres BOOLEAN;
+
+-- Fyll inn data fra avklaringkode til avklaring
+UPDATE avklaring
+SET kode          = avklaringkode.kode,
+    tittel        = avklaringkode.tittel,
+    beskrivelse   = avklaringkode.beskrivelse,
+    kan_kvitteres = avklaringkode.kan_kvitteres
+FROM avklaringkode
+WHERE avklaringkode.kode = avklaring.avklaring_kode;
+
+-- Sett nye kolonner i avklaring til NOT NULL
+ALTER TABLE avklaring
+    ALTER COLUMN kode SET NOT NULL,
+    ALTER COLUMN tittel SET NOT NULL,
+    ALTER COLUMN beskrivelse SET NOT NULL,
+    ALTER COLUMN kan_kvitteres SET NOT NULL;
+
+-- Slett avklaringkode
+ALTER TABLE avklaring
+    DROP COLUMN avklaring_kode;
+DROP TABLE avklaringkode;

--- a/mediator/src/test/kotlin/no/nav/dagpenger/behandling/db/PostgresMigrationTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/behandling/db/PostgresMigrationTest.kt
@@ -10,7 +10,7 @@ class PostgresMigrationTest {
     fun `Migration scripts are applied successfully`() {
         withCleanDb {
             val migrations = runMigration()
-            migrations shouldBeExactly 12
+            migrations shouldBeExactly 13
         }
     }
 }


### PR DESCRIPTION
Når vi normaliserer avklaringkode fører det til to problemer:

1. Når vi endrer en eksisterende avklaringskode i koden vil vi også mutere gamle behandlinger hvor avklaringen kanskje allerede er sjekket ut.
2. Nå er avklaringskode-tabellen en global som påvirkes av alle lagringer av alle behandlinger, uavhengig av person. Dette har ført til en del deadlocks.

Ved å lagre tekst og tittel rett i avklaringstabellen beholder vi et unikt sett av avklaringer for *denne* behandlingen, også over tid. Det eliminerer også behovet for locking og skriving på tvers av alle behandlinger.