### PR TITLE
Nedgraderer til java 21 image for å få opentelemetry til å snurre.

### DIFF
--- a/mediator/Dockerfile
+++ b/mediator/Dockerfile
@@ -1,4 +1,4 @@
-FROM cgr.dev/chainguard/jre:latest
+FROM gcr.io/distroless/java21
 
 ENV LANG='nb_NO.UTF-8' LANGUAGE='nb_NO:nb' LC_ALL='nb:NO.UTF-8' TZ="Europe/Oslo"
 


### PR DESCRIPTION
Fiks av opentelemetry agent feil. Slik jeg tolker det funker ikke opentelemetry agenten for java 23 enda som vi fikk fra `cgr.dev/chainguard/jre:latest`. Fant ikke ut hvordan en fikk en java 21  versjon fra chainguard uten å betalen. Prøver derfor googe sin distroless versjon. 

`Caused by: java.lang.reflect.InaccessibleObjectException: Unable to make protected final java.lang.Class java.lang.ClassLoader.findLoadedClass(java.lang.String) accessible: module java.base does not "opens java.lang" to unnamed module @4cdbe50f`