### PR TITLE
Feature/opplysningsverdi api

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -70,7 +70,7 @@ jobs:
   deploy-dev:
     name: Deploy to dev
     needs: [ build ]
-    # if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     environment: dev-gcp
     steps:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -70,7 +70,7 @@ jobs:
   deploy-dev:
     name: Deploy to dev
     needs: [ build ]
-    if: github.ref == 'refs/heads/main'
+    # if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     environment: dev-gcp
     steps:

--- a/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/api/BehandlingApi.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/api/BehandlingApi.kt
@@ -21,11 +21,11 @@ import io.opentelemetry.api.trace.Span
 import mu.KotlinLogging
 import mu.withLoggingContext
 import no.nav.dagpenger.aktivitetslogg.AuditOperasjon
+import no.nav.dagpenger.behandling.api.models.AvklaringKvitteringDTO
 import no.nav.dagpenger.behandling.api.models.DataTypeDTO
 import no.nav.dagpenger.behandling.api.models.IdentForesporselDTO
-import no.nav.dagpenger.behandling.api.models.KvitterAvklaringRequestDTO
 import no.nav.dagpenger.behandling.api.models.KvitteringDTO
-import no.nav.dagpenger.behandling.api.models.OppdaterOpplysningRequestDTO
+import no.nav.dagpenger.behandling.api.models.OppdaterOpplysningDTO
 import no.nav.dagpenger.behandling.api.models.OpplysningstypeDTO
 import no.nav.dagpenger.behandling.api.models.RekjoringDTO
 import no.nav.dagpenger.behandling.api.models.SaksbehandlerbegrunnelseDTO
@@ -97,15 +97,15 @@ internal fun Application.behandlingApi(
                         navn = it.navn,
                         datatype =
                             when (it.datatype) {
-                                Boolsk -> DataTypeDTO.boolsk
-                                Dato -> DataTypeDTO.dato
-                                Desimaltall -> DataTypeDTO.desimaltall
-                                Heltall -> DataTypeDTO.heltall
-                                ULID -> DataTypeDTO.ulid
-                                Penger -> DataTypeDTO.penger
-                                InntektDataType -> DataTypeDTO.inntekt
-                                BarnDatatype -> DataTypeDTO.barn
-                                Tekst -> DataTypeDTO.tekst
+                                Boolsk -> DataTypeDTO.BOOLSK
+                                Dato -> DataTypeDTO.DATO
+                                Desimaltall -> DataTypeDTO.DESIMALTALL
+                                Heltall -> DataTypeDTO.HELTALL
+                                ULID -> DataTypeDTO.ULID
+                                Penger -> DataTypeDTO.PENGER
+                                InntektDataType -> DataTypeDTO.INNTEKT
+                                BarnDatatype -> DataTypeDTO.BARN
+                                Tekst -> DataTypeDTO.TEKST
                                 PeriodeDataType -> TODO()
                             },
                     )
@@ -285,7 +285,7 @@ internal fun Application.behandlingApi(
                         withLoggingContext(
                             "behandlingId" to behandlingId.toString(),
                         ) {
-                            val oppdaterOpplysningRequestDTO = call.receive<OppdaterOpplysningRequestDTO>()
+                            val oppdaterOpplysningRequestDTO = call.receive<OppdaterOpplysningDTO>()
                             val behandling = hentBehandling(personRepository, behandlingId)
 
                             if (behandling.harTilstand(Redigert)) {
@@ -330,7 +330,7 @@ internal fun Application.behandlingApi(
                             "behandlingId" to behandlingId.toString(),
                         ) {
                             val avklaringId = call.avklaringId
-                            val kvitteringDTO = call.receive<KvitterAvklaringRequestDTO>()
+                            val kvitteringDTO = call.receive<AvklaringKvitteringDTO>()
                             val behandling = hentBehandling(personRepository, behandlingId)
 
                             require(!behandling.harTilstand(Redigert)) { "Kan ikke avklare om behandling står i tilstanden Redigert" }
@@ -416,7 +416,7 @@ private val OtelTraceIdPlugin =
 
 @Suppress("UNCHECKED_CAST")
 private class HttpVerdiMapper(
-    private val oppdaterOpplysningRequestDTO: OppdaterOpplysningRequestDTO,
+    private val oppdaterOpplysningRequestDTO: OppdaterOpplysningDTO,
 ) : VerdiMapper {
     override fun <T : Comparable<T>> map(datatype: Datatype<T>): T =
         when (datatype) {

--- a/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/api/BehandlingApiMapper.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/api/BehandlingApiMapper.kt
@@ -346,15 +346,14 @@ internal fun Opplysning<*>.tilOpplysningDTO(opplysninger: LesbarOpplysninger): O
                     BarnelisteDTO(
                         (this.verdi as BarnListe).map {
                             BarnVerdiDTO(
-                                fødselsdato = it.fødselsdato,
-                                fornavnOgMellomnavn = it.fornavnOgMellomnavn,
-                                etternavn = it.etternavn,
-                                statsborgerskap = it.statsborgerskap,
-                                kvalifiserer = it.kvalifiserer,
+                                it.fødselsdato,
+                                it.fornavnOgMellomnavn,
+                                it.etternavn,
+                                it.statsborgerskap,
+                                it.kvalifiserer,
                             )
                         },
                     )
-
                 Boolsk -> BoolskVerdiDTO(this.verdi as Boolean)
                 Dato -> DatoVerdiDTO(this.verdi as LocalDate)
                 Desimaltall -> DesimaltallVerdiDTO(this.verdi as Double)
@@ -363,14 +362,9 @@ internal fun Opplysning<*>.tilOpplysningDTO(opplysninger: LesbarOpplysninger): O
                 Penger -> DesimaltallVerdiDTO((this.verdi as Beløp).uavrundet.toDouble())
                 PeriodeDataType ->
                     (this.verdi as no.nav.dagpenger.opplysning.verdier.Periode).let {
-                        PeriodeVerdiDTO(
-                            fom = it.fraOgMed,
-                            tom = it.tilOgMed,
-                        )
+                        PeriodeVerdiDTO(it.fraOgMed, it.tilOgMed)
                     }
-
-                Tekst -> TekstVerdiDTO(verdi = this.verdi.toString())
-                ULID -> TekstVerdiDTO(verdi = this.verdi.toString())
+                Tekst, ULID -> TekstVerdiDTO(this.verdi.toString())
             },
         gyldigFraOgMed = this.gyldighetsperiode.fom.tilApiDato(),
         gyldigTilOgMed = this.gyldighetsperiode.tom.tilApiDato(),

--- a/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/api/BehandlingApiMapper.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/api/BehandlingApiMapper.kt
@@ -4,19 +4,27 @@ import mu.KotlinLogging
 import mu.withLoggingContext
 import no.nav.dagpenger.avklaring.Avklaring
 import no.nav.dagpenger.behandling.api.models.AvklaringDTO
+import no.nav.dagpenger.behandling.api.models.AvklaringDTOStatusDTO
 import no.nav.dagpenger.behandling.api.models.BegrunnelseDTO
 import no.nav.dagpenger.behandling.api.models.BehandlingDTO
+import no.nav.dagpenger.behandling.api.models.BehandlingDTOTilstandDTO
 import no.nav.dagpenger.behandling.api.models.BehandlingOpplysningerDTO
+import no.nav.dagpenger.behandling.api.models.BehandlingOpplysningerDTOTilstandDTO
 import no.nav.dagpenger.behandling.api.models.DataTypeDTO
 import no.nav.dagpenger.behandling.api.models.HendelseDTO
 import no.nav.dagpenger.behandling.api.models.HjemmelDTO
 import no.nav.dagpenger.behandling.api.models.LovkildeDTO
 import no.nav.dagpenger.behandling.api.models.OpplysningDTO
+import no.nav.dagpenger.behandling.api.models.OpplysningDTOFormålDTO
+import no.nav.dagpenger.behandling.api.models.OpplysningDTOStatusDTO
 import no.nav.dagpenger.behandling.api.models.OpplysningskildeDTO
+import no.nav.dagpenger.behandling.api.models.OpplysningskildeDTOTypeDTO
 import no.nav.dagpenger.behandling.api.models.RegelDTO
 import no.nav.dagpenger.behandling.api.models.RegelsettDTO
+import no.nav.dagpenger.behandling.api.models.RegelsettDTOStatusDTO
 import no.nav.dagpenger.behandling.api.models.SaksbehandlerDTO
 import no.nav.dagpenger.behandling.api.models.SaksbehandlersVurderingerDTO
+import no.nav.dagpenger.behandling.api.models.TekstVerdiDTO
 import no.nav.dagpenger.behandling.api.models.UtledningDTO
 import no.nav.dagpenger.behandling.modell.Behandling
 import no.nav.dagpenger.behandling.modell.hendelser.MeldekortId
@@ -31,6 +39,7 @@ import no.nav.dagpenger.opplysning.Hypotese
 import no.nav.dagpenger.opplysning.InntektDataType
 import no.nav.dagpenger.opplysning.LesbarOpplysninger
 import no.nav.dagpenger.opplysning.Opplysning
+import no.nav.dagpenger.opplysning.Opplysningsformål
 import no.nav.dagpenger.opplysning.Penger
 import no.nav.dagpenger.opplysning.PeriodeDataType
 import no.nav.dagpenger.opplysning.Redigerbar
@@ -123,15 +132,15 @@ internal fun Behandling.tilBehandlingDTO(): BehandlingDTO =
             utfall = utfall,
             tilstand =
                 when (this.tilstand().first) {
-                    Behandling.TilstandType.UnderOpprettelse -> BehandlingDTO.Tilstand.UnderOpprettelse
-                    Behandling.TilstandType.UnderBehandling -> BehandlingDTO.Tilstand.UnderBehandling
-                    Behandling.TilstandType.ForslagTilVedtak -> BehandlingDTO.Tilstand.ForslagTilVedtak
-                    Behandling.TilstandType.Låst -> BehandlingDTO.Tilstand.Låst
-                    Behandling.TilstandType.Avbrutt -> BehandlingDTO.Tilstand.Avbrutt
-                    Behandling.TilstandType.Ferdig -> BehandlingDTO.Tilstand.Ferdig
-                    Behandling.TilstandType.Redigert -> BehandlingDTO.Tilstand.Redigert
-                    Behandling.TilstandType.TilGodkjenning -> BehandlingDTO.Tilstand.TilGodkjenning
-                    Behandling.TilstandType.TilBeslutning -> BehandlingDTO.Tilstand.TilBeslutning
+                    Behandling.TilstandType.UnderOpprettelse -> BehandlingDTOTilstandDTO.UNDER_OPPRETTELSE
+                    Behandling.TilstandType.UnderBehandling -> BehandlingDTOTilstandDTO.UNDER_BEHANDLING
+                    Behandling.TilstandType.ForslagTilVedtak -> BehandlingDTOTilstandDTO.FORSLAG_TIL_VEDTAK
+                    Behandling.TilstandType.Låst -> BehandlingDTOTilstandDTO.LÅST
+                    Behandling.TilstandType.Avbrutt -> BehandlingDTOTilstandDTO.AVBRUTT
+                    Behandling.TilstandType.Ferdig -> BehandlingDTOTilstandDTO.FERDIG
+                    Behandling.TilstandType.Redigert -> BehandlingDTOTilstandDTO.REDIGERT
+                    Behandling.TilstandType.TilGodkjenning -> BehandlingDTOTilstandDTO.TIL_GODKJENNING
+                    Behandling.TilstandType.TilBeslutning -> BehandlingDTOTilstandDTO.TIL_BESLUTNING
                 },
             vilkår =
                 behandler.regelverk
@@ -201,11 +210,11 @@ private fun Regelsett.tilRegelsettDTO(
     val erRelevant = påvirkerResultat(lesbarOpplysninger)
 
     if (!erRelevant) {
-        status = RegelsettDTO.Status.IkkeRelevant
+        status = RegelsettDTOStatusDTO.IKKE_RELEVANT
     }
 
     if (egneAvklaringer.any { it.måAvklares() }) {
-        status = RegelsettDTO.Status.HarAvklaring
+        status = RegelsettDTOStatusDTO.HAR_AVKLARING
     }
 
     return RegelsettDTO(
@@ -225,13 +234,13 @@ private fun Regelsett.tilRegelsettDTO(
     )
 }
 
-private fun tilStatus(utfall: List<Opplysning<Boolean>>): RegelsettDTO.Status {
-    if (utfall.isEmpty()) return RegelsettDTO.Status.Info
+private fun tilStatus(utfall: List<Opplysning<Boolean>>): RegelsettDTOStatusDTO {
+    if (utfall.isEmpty()) return RegelsettDTOStatusDTO.INFO
 
     return if (utfall.all { it.verdi }) {
-        RegelsettDTO.Status.Oppfylt
+        RegelsettDTOStatusDTO.OPPFYLT
     } else {
-        RegelsettDTO.Status.IkkeOppfylt
+        RegelsettDTOStatusDTO.IKKE_OPPFYLT
     }
 }
 
@@ -242,15 +251,15 @@ internal fun Behandling.tilBehandlingOpplysningerDTO(): BehandlingOpplysningerDT
             behandlingId = this.behandlingId,
             tilstand =
                 when (this.tilstand().first) {
-                    Behandling.TilstandType.UnderOpprettelse -> BehandlingOpplysningerDTO.Tilstand.UnderOpprettelse
-                    Behandling.TilstandType.UnderBehandling -> BehandlingOpplysningerDTO.Tilstand.UnderBehandling
-                    Behandling.TilstandType.ForslagTilVedtak -> BehandlingOpplysningerDTO.Tilstand.ForslagTilVedtak
-                    Behandling.TilstandType.Låst -> BehandlingOpplysningerDTO.Tilstand.Låst
-                    Behandling.TilstandType.Avbrutt -> BehandlingOpplysningerDTO.Tilstand.Avbrutt
-                    Behandling.TilstandType.Ferdig -> BehandlingOpplysningerDTO.Tilstand.Ferdig
-                    Behandling.TilstandType.Redigert -> BehandlingOpplysningerDTO.Tilstand.Redigert
-                    Behandling.TilstandType.TilGodkjenning -> BehandlingOpplysningerDTO.Tilstand.TilGodkjenning
-                    Behandling.TilstandType.TilBeslutning -> BehandlingOpplysningerDTO.Tilstand.TilBeslutning
+                    Behandling.TilstandType.UnderOpprettelse -> BehandlingOpplysningerDTOTilstandDTO.UNDER_OPPRETTELSE
+                    Behandling.TilstandType.UnderBehandling -> BehandlingOpplysningerDTOTilstandDTO.UNDER_BEHANDLING
+                    Behandling.TilstandType.ForslagTilVedtak -> BehandlingOpplysningerDTOTilstandDTO.FORSLAG_TIL_VEDTAK
+                    Behandling.TilstandType.Låst -> BehandlingOpplysningerDTOTilstandDTO.LÅST
+                    Behandling.TilstandType.Avbrutt -> BehandlingOpplysningerDTOTilstandDTO.AVBRUTT
+                    Behandling.TilstandType.Ferdig -> BehandlingOpplysningerDTOTilstandDTO.FERDIG
+                    Behandling.TilstandType.Redigert -> BehandlingOpplysningerDTOTilstandDTO.REDIGERT
+                    Behandling.TilstandType.TilGodkjenning -> BehandlingOpplysningerDTOTilstandDTO.TIL_GODKJENNING
+                    Behandling.TilstandType.TilBeslutning -> BehandlingOpplysningerDTOTilstandDTO.TIL_BESLUTNING
                 },
             opplysning =
                 lesbareOpplysninger.finnAlle().map { opplysning ->
@@ -294,9 +303,9 @@ internal fun Avklaring.tilAvklaringDTO(): AvklaringDTO {
         kanKvitteres = kanKvitteres,
         status =
             when (sisteEndring) {
-                is Avklaring.Endring.Avbrutt -> AvklaringDTO.Status.Avbrutt
-                is Avklaring.Endring.Avklart -> AvklaringDTO.Status.Avklart
-                is Avklaring.Endring.UnderBehandling -> AvklaringDTO.Status.Åpen
+                is Avklaring.Endring.Avbrutt -> AvklaringDTOStatusDTO.AVBRUTT
+                is Avklaring.Endring.Avklart -> AvklaringDTOStatusDTO.AVKLART
+                is Avklaring.Endring.UnderBehandling -> AvklaringDTOStatusDTO.ÅPEN
             },
         maskinelt = sisteEndring !is Avklaring.Endring.UnderBehandling && saksbehandler == null,
         begrunnelse = saksbehandlerEndring?.begrunnelse,
@@ -318,23 +327,36 @@ internal fun Opplysning<*>.tilOpplysningDTO(opplysninger: LesbarOpplysninger): O
             },
         status =
             when (this) {
-                is Faktum -> OpplysningDTO.Status.Faktum
-                is Hypotese -> OpplysningDTO.Status.Hypotese
+                is Faktum -> OpplysningDTOStatusDTO.FAKTUM
+                is Hypotese -> OpplysningDTOStatusDTO.HYPOTESE
+            },
+        verdien =
+            when (this.opplysningstype.datatype) {
+                BarnDatatype -> TODO()
+                Boolsk -> TODO()
+                Dato -> TODO()
+                Desimaltall -> TODO()
+                Heltall -> TODO()
+                InntektDataType -> TODO()
+                Penger -> TODO()
+                PeriodeDataType -> TODO()
+                Tekst -> TekstVerdiDTO(verdi = this.verdi.toString())
+                ULID -> TODO()
             },
         gyldigFraOgMed = this.gyldighetsperiode.fom.tilApiDato(),
         gyldigTilOgMed = this.gyldighetsperiode.tom.tilApiDato(),
         datatype =
             when (this.opplysningstype.datatype) {
-                Boolsk -> DataTypeDTO.boolsk
-                Dato -> DataTypeDTO.dato
-                Desimaltall -> DataTypeDTO.desimaltall
-                Heltall -> DataTypeDTO.heltall
-                ULID -> DataTypeDTO.ulid
-                Penger -> DataTypeDTO.penger
-                InntektDataType -> DataTypeDTO.inntekt
-                BarnDatatype -> DataTypeDTO.barn
-                Tekst -> DataTypeDTO.tekst
-                PeriodeDataType -> DataTypeDTO.dato // TODO
+                Boolsk -> DataTypeDTO.BOOLSK
+                Dato -> DataTypeDTO.DATO
+                Desimaltall -> DataTypeDTO.DESIMALTALL
+                Heltall -> DataTypeDTO.HELTALL
+                ULID -> DataTypeDTO.ULID
+                Penger -> DataTypeDTO.PENGER
+                InntektDataType -> DataTypeDTO.INNTEKT
+                BarnDatatype -> DataTypeDTO.BARN
+                Tekst -> DataTypeDTO.TEKST
+                PeriodeDataType -> DataTypeDTO.DATO // TODO
             },
         kilde =
             this.kilde?.let {
@@ -342,7 +364,7 @@ internal fun Opplysning<*>.tilOpplysningDTO(opplysninger: LesbarOpplysninger): O
                 when (it) {
                     is Saksbehandlerkilde ->
                         OpplysningskildeDTO(
-                            OpplysningskildeDTO.Type.Saksbehandler,
+                            OpplysningskildeDTOTypeDTO.SAKSBEHANDLER,
                             ident = it.saksbehandler.ident,
                             begrunnelse = it.begrunnelse?.let { BegrunnelseDTO(it.verdi, it.sistEndret) },
                             registrert = registrert,
@@ -350,7 +372,7 @@ internal fun Opplysning<*>.tilOpplysningDTO(opplysninger: LesbarOpplysninger): O
 
                     is Systemkilde ->
                         OpplysningskildeDTO(
-                            OpplysningskildeDTO.Type.System,
+                            OpplysningskildeDTOTypeDTO.SYSTEM,
                             meldingId = it.meldingsreferanseId,
                             registrert = registrert,
                         )
@@ -366,7 +388,13 @@ internal fun Opplysning<*>.tilOpplysningDTO(opplysninger: LesbarOpplysninger): O
         redigerbar = this.kanRedigeres(redigerbareOpplysninger),
         kanOppfriskes = this.kanOppfriskes(),
         synlig = this.opplysningstype.synlig(opplysninger),
-        formål = OpplysningDTO.Formål.valueOf(this.opplysningstype.formål.name),
+        formål =
+            when (this.opplysningstype.formål) {
+                Opplysningsformål.Legacy -> OpplysningDTOFormålDTO.LEGACY
+                Opplysningsformål.Bruker -> OpplysningDTOFormålDTO.BRUKER
+                Opplysningsformål.Register -> OpplysningDTOFormålDTO.REGISTER
+                Opplysningsformål.Regel -> OpplysningDTOFormålDTO.REGEL
+            },
     )
 
 private fun LocalDate.tilApiDato(): LocalDate? =

--- a/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/api/BehandlingApiMapper.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/api/BehandlingApiMapper.kt
@@ -349,7 +349,7 @@ internal fun Opplysning<*>.tilOpplysningDTO(opplysninger: LesbarOpplysninger): O
                                 fødselsdato = it.fødselsdato,
                                 fornavnOgMellomnavn = it.fornavnOgMellomnavn,
                                 etternavn = it.etternavn,
-                                statsborgerskap = it.etternavn,
+                                statsborgerskap = it.statsborgerskap,
                                 kvalifiserer = it.kvalifiserer,
                             )
                         },

--- a/mediator/src/test/kotlin/no/nav/dagpenger/behandling/mediator/api/BehandlingApiTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/behandling/mediator/api/BehandlingApiTest.kt
@@ -29,7 +29,7 @@ import io.mockk.verify
 import no.nav.dagpenger.avklaring.Avklaring
 import no.nav.dagpenger.behandling.TestOpplysningstyper
 import no.nav.dagpenger.behandling.api.models.BehandlingDTO
-import no.nav.dagpenger.behandling.api.models.HendelseDTO
+import no.nav.dagpenger.behandling.api.models.HendelseDTOTypeDTO
 import no.nav.dagpenger.behandling.api.models.SaksbehandlerDTO
 import no.nav.dagpenger.behandling.api.models.SaksbehandlersVurderingerDTO
 import no.nav.dagpenger.behandling.db.InMemoryPersonRepository
@@ -277,7 +277,7 @@ internal class BehandlingApiTest {
 
             with(behandlingDto.behandletHendelse) {
                 shouldNotBeNull()
-                type shouldBe HendelseDTO.Type.Søknad
+                type shouldBe HendelseDTOTypeDTO.SØKNAD
                 id shouldBe hendelse.eksternId.id.toString()
             }
             with(behandlingDto.vilkår.single { it.navn == "Minsteinntekt" }) {
@@ -362,7 +362,7 @@ internal class BehandlingApiTest {
 
             with(behandlingDto.regelsett.single { it.navn == "Søknadstidspunkt" }) {
                 avklaringer.shouldBeEmpty()
-                opplysningIder?.shouldHaveSize(1)
+                opplysningIder.shouldHaveSize(1)
             }
 
             with(behandlingDto.avklaringer.single { it.kode == "tittel 2" }) {

--- a/mediator/src/test/kotlin/no/nav/dagpenger/behandling/mediator/api/BehandlingApiTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/behandling/mediator/api/BehandlingApiTest.kt
@@ -59,6 +59,7 @@ import no.nav.dagpenger.opplysning.Systemkilde
 import no.nav.dagpenger.opplysning.verdier.Barn
 import no.nav.dagpenger.opplysning.verdier.BarnListe
 import no.nav.dagpenger.opplysning.verdier.Beløp
+import no.nav.dagpenger.opplysning.verdier.Periode
 import no.nav.dagpenger.regel.Avklaringspunkter
 import no.nav.dagpenger.regel.Minsteinntekt
 import no.nav.dagpenger.regel.SøknadInnsendtHendelse
@@ -166,6 +167,10 @@ internal class BehandlingApiTest {
                         Faktum(
                             opplysningstype = TestOpplysningstyper.beløpA,
                             verdi = Beløp(1000.toBigDecimal()),
+                        ),
+                        Faktum(
+                            opplysningstype = TestOpplysningstyper.periode,
+                            verdi = Periode(LocalDate.now(), LocalDate.now().plusDays(10)),
                         ),
                         Faktum(
                             opplysningstype = TestOpplysningstyper.barn,

--- a/mediator/src/test/kotlin/no/nav/dagpenger/behandling/mediator/api/BehandlingApiTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/behandling/mediator/api/BehandlingApiTest.kt
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
-import com.fasterxml.jackson.module.kotlin.readValue
 import com.github.navikt.tbd_libs.naisful.test.TestContext
 import com.github.navikt.tbd_libs.rapids_and_rivers.test_support.TestRapid
 import io.kotest.assertions.throwables.shouldNotThrowAny
@@ -28,10 +27,18 @@ import io.mockk.spyk
 import io.mockk.verify
 import no.nav.dagpenger.avklaring.Avklaring
 import no.nav.dagpenger.behandling.TestOpplysningstyper
+import no.nav.dagpenger.behandling.api.models.BarnelisteDTO
 import no.nav.dagpenger.behandling.api.models.BehandlingDTO
+import no.nav.dagpenger.behandling.api.models.BoolskVerdiDTO
+import no.nav.dagpenger.behandling.api.models.DataTypeDTO
+import no.nav.dagpenger.behandling.api.models.DesimaltallVerdiDTO
+import no.nav.dagpenger.behandling.api.models.HeltallVerdiDTO
 import no.nav.dagpenger.behandling.api.models.HendelseDTOTypeDTO
+import no.nav.dagpenger.behandling.api.models.OpplysningDTO
+import no.nav.dagpenger.behandling.api.models.PeriodeVerdiDTO
 import no.nav.dagpenger.behandling.api.models.SaksbehandlerDTO
 import no.nav.dagpenger.behandling.api.models.SaksbehandlersVurderingerDTO
+import no.nav.dagpenger.behandling.april
 import no.nav.dagpenger.behandling.db.InMemoryPersonRepository
 import no.nav.dagpenger.behandling.mediator.HendelseMediator
 import no.nav.dagpenger.behandling.mediator.api.TestApplication.autentisert
@@ -48,7 +55,6 @@ import no.nav.dagpenger.behandling.modell.hendelser.BesluttBehandlingHendelse
 import no.nav.dagpenger.behandling.modell.hendelser.GodkjennBehandlingHendelse
 import no.nav.dagpenger.behandling.modell.hendelser.RekjørBehandlingHendelse
 import no.nav.dagpenger.behandling.modell.hendelser.SendTilbakeHendelse
-import no.nav.dagpenger.behandling.objectMapper
 import no.nav.dagpenger.opplysning.Avklaringkode
 import no.nav.dagpenger.opplysning.Faktum
 import no.nav.dagpenger.opplysning.Opplysning
@@ -71,7 +77,6 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
 import java.time.LocalDateTime
-import kotlin.collections.first
 
 internal class BehandlingApiTest {
     private val ident = "12345123451"
@@ -170,7 +175,7 @@ internal class BehandlingApiTest {
                         ),
                         Faktum(
                             opplysningstype = TestOpplysningstyper.periode,
-                            verdi = Periode(LocalDate.now(), LocalDate.now().plusDays(10)),
+                            verdi = Periode(16.april(2025), 25.april(2025)),
                         ),
                         Faktum(
                             opplysningstype = TestOpplysningstyper.barn,
@@ -178,7 +183,10 @@ internal class BehandlingApiTest {
                                 BarnListe(
                                     listOf(
                                         Barn(
-                                            LocalDate.now(),
+                                            fornavnOgMellomnavn = "Navn",
+                                            etternavn = "Navnesen",
+                                            statsborgerskap = "NOR",
+                                            fødselsdato = LocalDate.now(),
                                             kvalifiserer = true,
                                         ),
                                     ),
@@ -285,19 +293,58 @@ internal class BehandlingApiTest {
                 avklaringer.single().kode shouldBe "InntektNesteKalendermåned"
             }
 
-            /*
-             * TODO: Testen bør bruke mer mocka data og ikke være så koblet til oppførsel i modellen
-            with(behandlingDto.vilkår.single { it.navn == "Verneplikt" }) {
-                avklaringer shouldHaveSize 1
-                val aktivAvklaring = behandling.aktiveAvklaringer().first()
-                with(avklaringer.single()) {
-                    kode shouldBe "Verneplikt"
-
-                    tittel shouldBe aktivAvklaring.kode.tittel
-                    beskrivelse shouldBe aktivAvklaring.kode.beskrivelse
-                    id shouldBe aktivAvklaring.id
+            // sanity check
+            with(behandlingDto.opplysninger) {
+                with(opplysning(TestOpplysningstyper.beløpA.navn)) {
+                    shouldNotBeNull()
+                    verdi shouldBe "1000"
+                    val desimaltallVerdiDTO: DesimaltallVerdiDTO = verdien.shouldBeInstanceOf()
+                    desimaltallVerdiDTO.verdi shouldBe 1000
+                    desimaltallVerdiDTO.datatype shouldBe DataTypeDTO.DESIMALTALL
                 }
-            }*/
+                with(opplysning(TestOpplysningstyper.boolsk.navn)) {
+                    shouldNotBeNull()
+                    verdi shouldBe "true"
+                    val boolsk: BoolskVerdiDTO = verdien.shouldBeInstanceOf()
+                    boolsk.verdi shouldBe true
+                    boolsk.datatype shouldBe DataTypeDTO.BOOLSK
+                }
+                with(opplysning(TestOpplysningstyper.periode.navn)) {
+                    shouldNotBeNull()
+                    verdi shouldBe "Periode(start=2025-04-16, endInclusive=2025-04-25)"
+                    val boolsk: PeriodeVerdiDTO = verdien.shouldBeInstanceOf()
+                    boolsk.fom shouldBe 16.april(2025)
+                    boolsk.tom shouldBe 25.april(2025)
+                    boolsk.datatype shouldBe DataTypeDTO.PERIODE
+                }
+                with(opplysning(TestOpplysningstyper.barn.navn)) {
+                    shouldNotBeNull()
+                    verdi.shouldNotBeEmpty()
+                    val barn: BarnelisteDTO = verdien.shouldBeInstanceOf()
+                    barn.verdi.shouldHaveSize(1)
+                    with(barn.verdi.first()) {
+                        fødselsdato shouldBe LocalDate.now()
+                        fornavnOgMellomnavn shouldBe "Navn"
+                        etternavn shouldBe "Navnesen"
+                        statsborgerskap shouldBe "NOR"
+                        kvalifiserer shouldBe true
+                    }
+                }
+                with(opplysning(TestOpplysningstyper.heltall.navn)) {
+                    shouldNotBeNull()
+                    verdi shouldBe "3"
+                    val boolsk: HeltallVerdiDTO = verdien.shouldBeInstanceOf()
+                    boolsk.verdi shouldBe 3
+                    boolsk.datatype shouldBe DataTypeDTO.HELTALL
+                }
+                with(opplysning(Minsteinntekt.inntekt12.navn)) {
+                    shouldNotBeNull()
+                    verdi shouldBe "3000.034"
+                    val desimaltallVerdiDTO: DesimaltallVerdiDTO = verdien.shouldBeInstanceOf()
+                    desimaltallVerdiDTO.verdi shouldBe 3000.034
+                    desimaltallVerdiDTO.datatype shouldBe DataTypeDTO.DESIMALTALL
+                }
+            }
 
             behandlingDto.avklaringer shouldHaveSize 3
 
@@ -560,3 +607,5 @@ internal class BehandlingApiTest {
                 .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
     }
 }
+
+private fun List<OpplysningDTO>.opplysning(navn: String) = find { it.navn == navn }

--- a/openapi/src/main/resources/behandling-api.yaml
+++ b/openapi/src/main/resources/behandling-api.yaml
@@ -363,15 +363,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              required:
-                - verdi
-                - begrunnelse
-              properties:
-                verdi:
-                  type: string
-                begrunnelse:
-                  type: string
+                $ref: '#/components/schemas/OppdaterOpplysning'
       responses:
         200:
           content:
@@ -436,12 +428,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              required:
-                - begrunnelse
-              properties:
-                begrunnelse:
-                  type: string
+              $ref: '#/components/schemas/AvklaringKvittering'
       responses:
         204:
           description: No Content
@@ -509,11 +496,28 @@ components:
           type: string
           pattern: '^\d{11}$'
 
+    OppdaterOpplysning:
+      type: object
+      required:
+        - verdi
+        - begrunnelse
+      properties:
+        verdi:
+          type: string
+        begrunnelse:
+          type: string
+
+    AvklaringKvittering:
+      type: object
+      required:
+        - begrunnelse
+      properties:
+        begrunnelse:
+          type: string
     Behandling:
       type: object
       required:
         - behandlingId
-        - opplysning
         - tilstand
         - kreverTotrinnskontroll
         - vilkår
@@ -754,6 +758,8 @@ components:
           $ref: '#/components/schemas/opplysningTypeId'
         navn:
           type: string
+        verdien:
+          $ref: '#/components/schemas/Opplysningsverdi'
         verdi:
           type: string
         status:
@@ -788,7 +794,28 @@ components:
           type: string
           enum: [ "Legacy", "Bruker", "Register", "Regel" ]
 
+    Opplysningsverdi:
+      type: object
+      oneOf:
+        - $ref: '#/components/schemas/TekstVerdi'
+      discriminator:
+        propertyName: datatype
+        mapping:
+          tekst: '#/components/schemas/TekstVerdi'
+
+    TekstVerdi:
+      type: object
+      properties:
+        verdi:
+          type: string
+        datatype:
+          $ref: '#/components/schemas/DataType'
+      required:
+        - verdi
+        - type
+
     Opplysningskilde:
+      type: object
       description: |
         Kilde for opplysningen
       required:

--- a/openapi/src/main/resources/behandling-api.yaml
+++ b/openapi/src/main/resources/behandling-api.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Behandling API
-  version: 1.0.2
+  version: 1.0.3
   description: API for å hente alle behandlinger.
   contact:
     name: '#team-dagpenger'

--- a/openapi/src/main/resources/behandling-api.yaml
+++ b/openapi/src/main/resources/behandling-api.yaml
@@ -363,7 +363,7 @@ paths:
         content:
           application/json:
             schema:
-                $ref: '#/components/schemas/OppdaterOpplysning'
+              $ref: '#/components/schemas/OppdaterOpplysning'
       responses:
         200:
           content:
@@ -795,13 +795,31 @@ components:
           enum: [ "Legacy", "Bruker", "Register", "Regel" ]
 
     Opplysningsverdi:
+      description: |
+        Verdi for opplysningen. Kan være en av flere datatyper, se datatype for å se hvilken datatype opplysningen har
       type: object
       oneOf:
         - $ref: '#/components/schemas/TekstVerdi'
+        - $ref: '#/components/schemas/DatoVerdi'
+        - $ref: '#/components/schemas/HeltallVerdi'
+        - $ref: '#/components/schemas/DesimaltallVerdi'
+        - $ref: '#/components/schemas/UlidVerdi'
+        - $ref: '#/components/schemas/BoolskVerdi'
+        - $ref: '#/components/schemas/PeriodeVerdi'
+        - $ref: '#/components/schemas/Barneliste'
       discriminator:
         propertyName: datatype
         mapping:
           tekst: '#/components/schemas/TekstVerdi'
+          barn: '#/components/schemas/Barneliste'
+          inntekt: '#/components/schemas/TekstVerdi'
+          dato: '#/components/schemas/DatoVerdi'
+          heltall: '#/components/schemas/HeltallVerdi'
+          desimaltall: '#/components/schemas/DesimaltallVerdi'
+          penger: '#/components/schemas/DesimaltallVerdi'
+          ulid: '#/components/schemas/UlidVerdi'
+          boolsk: '#/components/schemas/BoolskVerdi'
+          periode: '#/components/schemas/PeriodeVerdi'
 
     TekstVerdi:
       type: object
@@ -812,7 +830,113 @@ components:
           $ref: '#/components/schemas/DataType'
       required:
         - verdi
-        - type
+        - datatype
+
+    DatoVerdi:
+      type: object
+      properties:
+        verdi:
+          type: string
+          format: date
+        datatype:
+          $ref: '#/components/schemas/DataType'
+      required:
+        - verdi
+        - datatype
+
+    HeltallVerdi:
+      type: object
+      properties:
+        verdi:
+          type: integer
+          format: int32
+        datatype:
+          $ref: '#/components/schemas/DataType'
+      required:
+        - verdi
+        - datatype
+
+    UlidVerdi:
+      type: object
+      properties:
+        verdi:
+          type: string
+        datatype:
+          $ref: '#/components/schemas/DataType'
+      required:
+        - verdi
+        - datatype
+
+    DesimaltallVerdi:
+      type: object
+      properties:
+        verdi:
+          type: number
+          format: double
+        datatype:
+          $ref: '#/components/schemas/DataType'
+      required:
+        - verdi
+        - datatype
+
+    BoolskVerdi:
+      type: object
+      properties:
+        verdi:
+          type: boolean
+        datatype:
+          $ref: '#/components/schemas/DataType'
+      required:
+        - verdi
+        - datatype
+
+    PeriodeVerdi:
+      type: object
+      properties:
+        fom:
+          type: string
+          format: date
+        tom:
+          type: string
+          format: date
+        datatype:
+          $ref: '#/components/schemas/DataType'
+      required:
+        - fom
+        - tom
+        - datatype
+
+
+    Barneliste:
+      type: object
+      properties:
+        verdi:
+          type: array
+          items:
+            $ref: '#/components/schemas/BarnVerdi'
+        datatype:
+          $ref: '#/components/schemas/DataType'
+      required:
+        - verdi
+        - datatype
+
+    BarnVerdi:
+      type: object
+      properties:
+        fødselsdato:
+          type: string
+          format: date
+        fornavnOgMellomnavn:
+          type: string
+        etternavn:
+          type: string
+        statsborgerskap:
+          type: string
+        kvalifiserer:
+          type: boolean
+      required:
+        - fødselsdato
+        - kvalifiserer
 
     Opplysningskilde:
       type: object

--- a/opplysninger/src/main/kotlin/no/nav/dagpenger/opplysning/Opplysningstype.kt
+++ b/opplysninger/src/main/kotlin/no/nav/dagpenger/opplysning/Opplysningstype.kt
@@ -13,10 +13,10 @@ interface Klassifiserbart {
 }
 
 enum class Opplysningsformål {
-    Legacy(),
-    Bruker(),
-    Register(),
-    Regel(),
+    Legacy,
+    Bruker,
+    Register,
+    Regel,
 }
 
 class Opplysningstype<T : Comparable<T>>(


### PR DESCRIPTION
Inspirasjon fra STSB som har gått over til [fabrikt](https://github.com/cjbooms/fabrikt) for å genere kotlin klasser fra openapi spec. 
Fabrikt støtter 'discriminator' (eg  polymorphism) sånn at opplysningsverdier kan ha type

eg

```
"navn": "Desimal",
      "verdien": {
        "verdi": 3.0,
        "datatype": "desimaltall"
      },
      "verdi": "3.0",
```

eller

```
  "navn": "Barn",
      "verdien": {
        "verdi": [
          {
            "fødselsdato": "2025-04-16",
            "fornavnOgMellomnavn": "Navn",
            "etternavn": "Navnesen",
            "statsborgerskap": "NOR",
            "kvalifiserer": true
          }
        ],
        "datatype": "barn"
      },
"verdi": "Barn(fødselsdato=2025-04-16, fornavnOgMellomnavn=Navn, \netternavn=Navnesen, statsborgerskap=NOR, kvalifiserer=true)"
```


Er ikke helt fornøyd med navn etc. Kom gjerne med innspill:) 